### PR TITLE
DELIA-53579 : tr69hostif crash with "nn_err_abort"

### DIFF
--- a/examples/rtRemoteAdaptor/rtRemoteAdapter.cpp
+++ b/examples/rtRemoteAdaptor/rtRemoteAdapter.cpp
@@ -83,7 +83,9 @@ rtError rtRemoteAdapter::connectParodus() {
  *  @return : void.
  */
 void rtRemoteAdapter::disconnectParodus() {
+	if(m_current_instance != NULL) {
     int res = libparodus_shutdown(&m_current_instance);
+	}
     if(res != RT_OK) {
         rtLogDebug("Failed to disconnect parodus: '%d'",res);
     }


### PR DESCRIPTION
Reason for change: Added check for crash.
Test Procedure: Refer Jira
Risks: Low

Change-Id: I14b019739fcc9531239b7ae0b42e07a754a34fd4
Signed-off-by: drajas861 <divyashree_rajasekar@comcast.com>