### PR TITLE
RDK-47122: rtremote Component fails with 64 Bit Compilation

### DIFF
--- a/src/rtRemoteValueWriter.cpp
+++ b/src/rtRemoteValueWriter.cpp
@@ -140,6 +140,8 @@ rtRemoteValueWriter::write(rtRemoteEnvironment* env, rtValue const& from,
     case RT_voidPtrType:
 #if __x86_64
       to.AddMember("value", (uint64_t)(from.toVoidPtr()), doc.GetAllocator());
+#elif __aarch64__
+      to.AddMember("value", (uint64_t)(from.toVoidPtr()), doc.GetAllocator());
 #else
       to.AddMember("value", (uint32_t)(from.toVoidPtr()), doc.GetAllocator());
 #endif


### PR DESCRIPTION
Reason for change: Fixing compilation issue with 64 bit migration
Test Procedure: To verify image and build success
Risks: Medium
Priority: P2
Signed-off-by: Rajkumar Durairajan <Rajkumar_Durairajan2@comcast.com>