### PR TITLE
RDKCOM-3563 RDKDEV-651 cleanup disconnected client

### DIFF
--- a/src/rtRemoteServer.cpp
+++ b/src/rtRemoteServer.cpp
@@ -488,6 +488,15 @@ rtRemoteServer::onClientStateChanged(std::shared_ptr<rtRemoteClient> const& clie
         ditr->second.clear();
         m_disconnected_callback_map.erase(ditr);
     }
+
+    // also remove the disconnected client from m_object_map
+    for (auto itr = m_object_map.begin(); itr != m_object_map.end();)
+    {
+      if (itr->second.get() == client.get())
+        itr = m_object_map.erase(itr);
+      else
+        ++itr;
+    }
   }
 
   return e;


### PR DESCRIPTION
RDKCOM-3563 RDKDEV-651 cleanup disconnected client

After socket shutdown, the client was still being kept in rtRemoteServer m_object_map, and subsequent findObject searches were trying to reuse this disconnected client instance.

(cherry picked from commit 3f79130484778c6d5ae15afbb32d9f00ee0af017)

Signed-off-by: tomasz-karczewski-red <tomasz.karczewski@redembedded.com>
